### PR TITLE
使用 env 获取 shell 路径

### DIFF
--- a/sign.sh
+++ b/sign.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RESET="\e[0m"
 RED="${RESET}\e[0;31m"


### PR DESCRIPTION
FreeBSD 操作系统的 bash 实际路径为 /usr/local/bin/bash，所以使用env来获取路径更合适
